### PR TITLE
chore: setting a assetPrefix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,4 +4,5 @@ const withMDX = require('@next/mdx')({
 
 module.exports = withMDX({
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  assetPrefix: process.env.NODE_ENV === 'production' ? '/md-note/' : '',
 });


### PR DESCRIPTION
## Overview

- プロジェクトのgithub pagesだとドメインの後に `/${repo_name}/` が付くのでその分の設定をnext側でした

## issue