### PR TITLE
chore: パッケージインストールcacheが効くようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM node:14.15.5-alpine
 
 WORKDIR /app
 
-ADD . /app
+# パッケージに変更があったときにインストールのcacheが更新される
+COPY package.json /app/package.json
+RUN yarn
 
-RUN yarn && yarn build
+# アプリケーションに変更があったときにcacheが更新される
+COPY . /app/
+RUN yarn build
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Overview

- docker buildで毎回パッケージをインストールされるようになっていたのでcacheが効くようにした

## issue

## 参考

- https://tech.plaid.co.jp/improve_docker_build_efficiency/